### PR TITLE
fix: Upload concurrency tests

### DIFF
--- a/tests/pre-exit-success.bats
+++ b/tests/pre-exit-success.bats
@@ -72,9 +72,8 @@ COMMON_CURL_OPTIONS='--form \* --form \* --form \* --form \* --form \* --form \*
   assert_output --partial "Uploading './tests/fixtures/junit-1.xml'..."
   assert_output --partial "Uploading './tests/fixtures/junit-2.xml'..."
   assert_output --partial "Uploading './tests/fixtures/junit-3.xml'..."
-  assert_output --partial "curl success 1"
-  assert_output --partial "curl success 1"
-  assert_output --partial "curl success 1"
+  
+  assert_equal "$(echo "$output" | grep -c "curl success")" "3"
 }
 
 @test "Single file pattern through array" {


### PR DESCRIPTION
# What?

Changes assert_output to assert_equal on concurrency test

# Why?

Due to issues with the way bats handles concurrency, the original code does not work as intended. The new code should correctly count the number of successes.